### PR TITLE
feat: 数据源面板插件支持数据mock

### DIFF
--- a/packages/plugin-datasource-pane/src/components/DataSourceForm/DataSourceForm.tsx
+++ b/packages/plugin-datasource-pane/src/components/DataSourceForm/DataSourceForm.tsx
@@ -1,6 +1,6 @@
 // @todo schema default
 import React, { PureComponent } from 'react';
-import { createForm, registerValidateRules } from '@formily/core';
+import { createForm, registerValidateRules, onFieldValueChange } from '@formily/core';
 import { createSchemaField } from '@formily/react';
 import {
   Space,
@@ -122,6 +122,29 @@ const SCHEMA = {
           default: {},
           'x-decorator-props': {
             addonAfter: <ComponentSwitchBtn component="LowcodeExpression" />,
+          },
+        },
+        mock: {
+          type: 'object',
+          title: '请求配置',
+          required: true,
+          name: 'mock',
+          properties: {
+            isMock: {
+              name: 'isMock',
+              title: '是否Mock请求',
+              type: 'boolean',
+              default: false,
+            },
+            responseData: {
+              name: 'mockResponseData',
+              type: 'string',
+              title: 'Mock响应数据',
+              'x-component': 'Input.TextArea',
+              'x-component-props': {
+                autoHeight: { minRows: 6, maxRows: 10 },
+              },
+            },
           },
         },
       },
@@ -461,6 +484,14 @@ export class DataSourceForm extends PureComponent<DataSourceFormProps> {
 
   form = createForm({
     initialValues: this.deriveInitialData(this.props.dataSource),
+    effects: () => {
+      // 设置mock开关和mock数据联动
+      onFieldValueChange('options.mock.isMock', (field: any) => {
+        this.form.setFieldState('*(options.mock.responseData)', (state) => {
+          state.display = field.value ? 'visible' : 'none';
+        });
+      });
+    },
   });
 
   render() {


### PR DESCRIPTION
我们实际项目中需要用到数据源mock能力，开启mock开关后可在下方输入mock内容，目前简单利用input实现，后续可以加json编辑器，mock之后数据源中会存在isMock属性和相关mock数据。
我们目前重写了数据源的requestHandle函数对mock数据进行处理，用法不限于此。