### PR TITLE
Sy296565890 patch 1

### DIFF
--- a/packages/plugin-code-editor/src/components/JSEditor/JsEditor.tsx
+++ b/packages/plugin-code-editor/src/components/JSEditor/JsEditor.tsx
@@ -248,13 +248,9 @@ export class JsEditor extends PureComponent<JsEditorProps, JsEditorState> {
       return;
     }
 
-    const pos = monacoEditor.getPosition();
+    // const pos = monacoEditor.getPosition();
     this.setState({ errorInfo, hasError, code: newCode, errorLocation }, () => {
-      if(hasError) {
-        pos.column += 1;
-        monacoEditor.setPosition(pos);
-      }
-
+      // monacoEditor.setPosition(pos);
       // update error decorations
       if (this.lastErrorDecoration) {
         monacoEditor.deltaDecorations(


### PR DESCRIPTION
monacoEditor.setPosition(pos); 多余的代码  导致每次输入或粘贴之后 光标总是停留在之前的位置

注释这段代码之后就正常了