### PR TITLE
fix: fixed the problem that the data source panel did not display the default value when it was initialized

### DIFF
--- a/packages/plugin-datasource-pane/src/pane/index.tsx
+++ b/packages/plugin-datasource-pane/src/pane/index.tsx
@@ -32,8 +32,6 @@ export interface DataSource {
   list: InterpretDataSourceConfig[];
 }
 
-const stateService = createStateService();
-
 export { DataSourceForm } from '../components/DataSourceForm';
 
 const PLUGIN_NAME = 'dataSourcePane';
@@ -83,6 +81,8 @@ export default class DataSourcePanePlugin extends PureComponent<
     exportPlugins: [],
   };
 
+  stateService = createStateService();
+
   state = {
     active: false,
     panelKey: 1,
@@ -110,11 +110,11 @@ export default class DataSourcePanePlugin extends PureComponent<
   }
 
   componentDidMount() {
-    stateService.start();
+    this.stateService.start();
   }
 
   componentWillUnmount() {
-    stateService.stop();
+    this.stateService.stop();
   }
 
   handleSchemaChange = (schema: DataSource) => {
@@ -166,7 +166,7 @@ export default class DataSourcePanePlugin extends PureComponent<
     return (
       <EditorContext.Provider value={{ project, logger, setters }}>
         <DataSourcePaneContext.Provider
-          value={{ stateService, dataSourceTypes }}
+          value={{ stateService: this.stateService, dataSourceTypes }}
         >
           <ErrorBoundary
             onError={onError}


### PR DESCRIPTION
fixed https://github.com/alibaba/lowcode-engine/issues/982

问题原因：面板组件有 Fixed 模式和 Float 模式，这两种模式的切换会导致面板所渲染的容器不一样，在这种情况下组件会重新进行初始化。

由于原来的 stateService 是单例，当 DataSourcePanePlugin 第二次初始化渲染时，componentDidMount 生命周期的重新执行导致数据被清空。