### PR TITLE
fix: correct spelling error in search component

### DIFF
--- a/packages/plugin-components-pane/src/index.tsx
+++ b/packages/plugin-components-pane/src/index.tsx
@@ -304,7 +304,7 @@ export default class ComponentPane extends React.Component<ComponentPaneProps, C
         <div className={cx('header')}>
           <Search
             className={cx('search')}
-            placeholder={this.t(createI18n('其他', 'Search components'))}
+            placeholder={this.t(createI18n('搜索组件', 'Search components'))}
             shape="simple"
             hasClear
             autoFocus


### PR DESCRIPTION
很抱歉中文搜索组件placeholder写错了，更改为正确的