### PR TITLE
fix: fix plugin datasource pane update when type changed

### DIFF
--- a/packages/plugin-datasource-pane/src/components/DataSourceForm/DataSourceForm.tsx
+++ b/packages/plugin-datasource-pane/src/components/DataSourceForm/DataSourceForm.tsx
@@ -42,11 +42,7 @@ const SCHEMA = {
     type: {
       title: '类型',
       type: 'string',
-      editable: false,
       readOnly: true,
-      hidden: true,
-      display: 'hidden',
-      visible: false,
       'x-decorator': 'FormItem',
       'x-component-props': {
         // labelWidth: 300,

--- a/packages/plugin-datasource-pane/src/components/DataSourceForm/DataSourceForm.tsx
+++ b/packages/plugin-datasource-pane/src/components/DataSourceForm/DataSourceForm.tsx
@@ -199,8 +199,10 @@ export class DataSourceForm extends PureComponent<DataSourceFormProps, { form: F
   }
 
   componentDidUpdate(prevProps: DataSourceFormProps) {
-    // dataSource 变了，需要更新 form，界面刷新
-    if (this.props.dataSource !== prevProps.dataSource) {
+    const type = this.props.dataSourceType?.type;
+    const ptype = prevProps.dataSourceType?.type;
+    // dataSource 或 dataSourceType.type 变了，需要更新 form，界面刷新
+    if (this.props.dataSource !== prevProps.dataSource || type !== ptype) {
       this.setState({
         form: this.createForm()
       })


### PR DESCRIPTION
解决问题：
1. 新建数据源时，如果先点新建 fetch，不关闭表单情况下再点新建 jsonp，表单类型 不会更新。

![image](https://user-images.githubusercontent.com/17904619/226571752-5c04114e-c2fc-431c-bdc8-e7c1a8e8657d.png)

解决方式：增加类型判断，如果类型变更，更新界面


2. 删除多余配置项，`editable`，`hidden`，`display`，`visible` 这个几个配置项实际上没有效果，影响判断
```javascript
type: {
      title: '类型',
      type: 'string',
      editable: false, // 与 readOnly 实现同样的效果，但实测无效，readOnly 有效
      readOnly: true,
      // 'x-display': 'hidden', // 下面三个配置项，看着是要隐藏表单，实测无效。如果需要隐藏应该使用 'x-display': 'hidden',
      hidden: true, // // 实测无效
      display: 'hidden',  // 实测无效
      visible: false,  // 实测无效
}
```


顺便提个建议，fetch 在实际使用的时候，普通用户甚至后端开发可能不理解 fetch 是什么意思，建议可以改成叫 http