### PR TITLE
fix: update dataSourcePane display when schema changed

### DIFF
--- a/packages/plugin-datasource-pane/src/pane/DataSourcePane.tsx
+++ b/packages/plugin-datasource-pane/src/pane/DataSourcePane.tsx
@@ -93,7 +93,11 @@ export class DataSourcePane extends PureComponent<
     });
     this.send({ type: 'UPDATE_DS', payload: this.props.initialSchema?.list });
   }
-
+  componentDidUpdate(newValue:DataSourcePaneProps) {
+    if (this.props.initialSchema !== newValue.initialSchema) {
+      this.send({ type: 'UPDATE_DS', payload: this.props.initialSchema?.list });
+    }
+  }
   componentWillUnmount() {
     this.serviceS?.unsubscribe?.();
   }


### PR DESCRIPTION
解决了datasource面板没有根据当前正在使用的schema中的datasource数据回显问题：https://github.com/alibaba/lowcode-engine/issues/1837