### PR TITLE
fix(code-editor): fixed @babel/preset-env version (7.22.9)

### DIFF
--- a/packages/plugin-code-editor/package.json
+++ b/packages/plugin-code-editor/package.json
@@ -24,7 +24,7 @@
     "@alilc/lowcode-plugin-base-monaco-editor": "^1.1.1",
     "@babel/core": "^7.15.8",
     "@babel/parser": "^7.15.8",
-    "@babel/preset-env": "^7.15.8",
+    "@babel/preset-env": "7.22.9",
     "@babel/preset-react": "^7.14.5",
     "@babel/standalone": "^7.15.8",
     "@babel/traverse": "^7.15.4",


### PR DESCRIPTION
in the @babel/preset-env version @7.22.10 version, changed the introduction method of plugin-syntax-xxxxxx. Causing the new version to be unusable.(https://github.com/babel/babel/commit/6b91b9b2af22251fe04f0b6f1d8f74c18a414a10#diff-2281f56422073bffd4b039230999ad8fe300fa0ce0fe9af45580695488c82f68) 
fix: [alibaba/lowcode-engine#](https://github.com/alibaba/lowcode-engine/issues/2357)