### PR TITLE
fix: schema2jsCode Compatibility issues

### DIFF
--- a/packages/plugin-code-editor/src/utils/schema-to-code.ts
+++ b/packages/plugin-code-editor/src/utils/schema-to-code.ts
@@ -98,7 +98,12 @@ function createFunctionCode(functionName: string, functionNode: Method) {
       functionCode = functionCode.replace(/function/, '');
     } else {
       // 兼容历史数据
-      functionCode = functionNode.value?.replace(/function/, functionName);
+      // 如果函数名称已经包含在函数定义中,需要移除重复的函数名
+      if (functionNode.value?.includes(`function ${functionName}`)) {
+        functionCode = functionNode.value?.replace(`function ${functionName}`, functionName);
+      } else {
+        functionCode = functionNode.value?.replace(/function/, functionName);
+      }
     }
     return functionCode;
   }


### PR DESCRIPTION
我想在运行时用户操作后生成一些自定义方法，修改了schema的methods，然后重新生成js code，发现一个兼容性问题，如果我在前端页面没有先打开js编辑器的面板的话，所有的function都会变成funcName funcName这种形式
```javascript
        (schema.componentsTree[0] as any).originCode = undefined;
        (schema.componentsTree[0] as any).originCode = await schema2JsCode(schema);
```
![image](https://github.com/user-attachments/assets/c65680dd-8c2a-40fd-b5fd-9f5349c192bf)
